### PR TITLE
Delete functionality for organization controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -74,7 +74,7 @@ public class UCSBOrganizationController extends ApiController {
     }
 
     
-/** 
+
     @Operation(summary= "Delete a UCSBOrganization")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("")
@@ -86,7 +86,7 @@ public class UCSBOrganizationController extends ApiController {
         ucsbOrganizationRepository.delete(organization);
         return genericMessage("UCSBOrganization with id %s deleted".formatted(orgCode));
     }
-
+/**
     @Operation(summary= "Update a single organization")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("")


### PR DESCRIPTION
Added delete functionality to organization controller.

Full mutation and jacoco coverage.

Check at https://team02-nbelle1-dev.dokku-06.cs.ucsb.edu

Closes #18